### PR TITLE
Initialize retro-peft-adapters package with setup and basic tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,146 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "retro-peft-adapters"
+version = "0.1.0"
+description = "Retrieval-augmented parameter-efficient adapters combining frozen key/value caching with local vector databases"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Daniel Schmidt", email = "daniel@terragonlabs.com"}
+]
+maintainers = [
+    {name = "Daniel Schmidt", email = "daniel@terragonlabs.com"}
+]
+keywords = ["peft", "rag", "retrieval", "adapters", "llm", "fine-tuning"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "torch>=1.12.0",
+    "transformers>=4.21.0",
+    "peft>=0.4.0",
+    "datasets>=2.0.0",
+    "accelerate>=0.20.0",
+    "numpy>=1.21.0",
+    "scikit-learn>=1.0.0",
+    "sentence-transformers>=2.2.0",
+]
+
+[project.optional-dependencies]
+faiss = ["faiss-cpu>=1.7.0"]
+faiss-gpu = ["faiss-gpu>=1.7.0"]
+qdrant = ["qdrant-client>=1.3.0"]
+weaviate = ["weaviate-client>=3.20.0"]
+all-backends = [
+    "faiss-cpu>=1.7.0",
+    "qdrant-client>=1.3.0",
+    "weaviate-client>=3.20.0"
+]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "black>=22.0.0",
+    "isort>=5.0.0",
+    "flake8>=5.0.0",
+    "mypy>=1.0.0",
+    "pre-commit>=2.20.0",
+    "sphinx>=5.0.0",
+    "sphinx-rtd-theme>=1.2.0",
+]
+test = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.8.0",
+    "hypothesis>=6.0.0",
+]
+docs = [
+    "sphinx>=5.0.0",
+    "sphinx-rtd-theme>=1.2.0",
+    "myst-parser>=0.18.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/yourusername/retro-peft-adapters"
+Documentation = "https://retro-peft-adapters.readthedocs.io"
+Repository = "https://github.com/yourusername/retro-peft-adapters"
+"Bug Tracker" = "https://github.com/yourusername/retro-peft-adapters/issues"
+Changelog = "https://github.com/yourusername/retro-peft-adapters/blob/main/CHANGELOG.md"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.black]
+line-length = 100
+target-version = ['py38', 'py39', 'py310', 'py311']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 100
+include_trailing_comma = true
+known_first_party = ["retro_peft"]
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra -q --strict-markers --strict-config"
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+branch = true
+source = ["src/retro_peft"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
+show_missing = true
+skip_covered = false

--- a/src/retro_peft/__init__.py
+++ b/src/retro_peft/__init__.py
@@ -1,0 +1,21 @@
+"""
+Retro-PEFT-Adapters: Retrieval-Augmented Parameter-Efficient Fine-Tuning
+
+This package provides retrieval-augmented parameter-efficient adapters that combine
+frozen key/value caching with local vector databases for instant domain adaptation.
+"""
+
+__version__ = "0.1.0"
+__author__ = "Daniel Schmidt"
+__email__ = "daniel@terragonlabs.com"
+
+# Core exports will be defined as implementation progresses
+# from .adapters import RetroLoRA, RetroAdaLoRA, RetroIA3
+# from .retrieval import VectorIndexBuilder, HybridRetriever
+# from .training import ContrastiveRetrievalTrainer
+
+__all__ = [
+    "__version__",
+    "__author__",
+    "__email__",
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for retro-peft-adapters."""

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,21 @@
+"""Basic tests to ensure package installation and imports work."""
+
+import sys
+from pathlib import Path
+
+# Add src to path for testing
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+def test_package_import():
+    """Test that the main package can be imported."""
+    import retro_peft
+    assert retro_peft.__version__ == "0.1.0"
+
+
+def test_package_metadata():
+    """Test package metadata is accessible."""
+    import retro_peft
+    assert hasattr(retro_peft, "__version__")
+    assert hasattr(retro_peft, "__author__")
+    assert hasattr(retro_peft, "__email__")


### PR DESCRIPTION
## Summary
- Introduces the `retro-peft-adapters` Python package with initial setup
- Adds `pyproject.toml` for project metadata, dependencies, and build configuration
- Creates package initialization file with version and author metadata
- Adds basic test suite to verify package import and metadata accessibility

## Changes

### Project Configuration
- Added `pyproject.toml` defining project metadata, dependencies, optional dependencies, and development tools
- Configured build system with setuptools and wheel
- Set Python compatibility from 3.8 to 3.11
- Included linting, formatting, type checking, and testing tool configurations

### Package Initialization
- Created `src/retro_peft/__init__.py` with package docstring and metadata variables
- Placeholder comments for future core exports

### Testing
- Added `tests/__init__.py` as test suite marker
- Added `tests/test_basic.py` with tests to ensure package imports correctly and metadata is accessible

## Test plan
- [x] Run tests to confirm package imports without errors
- [x] Verify version, author, and email metadata are present and correct
- [x] Confirm `pyproject.toml` dependencies and configurations are valid and installable

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6d5ab6f2-ec3f-4d35-a226-bd0a13c51598